### PR TITLE
Support games without reverse holo

### DIFF
--- a/core.py
+++ b/core.py
@@ -4,6 +4,7 @@ import sys
 import json
 import base64
 import logging
+import platform
 
 from decimal import Decimal
 from pathlib import Path
@@ -57,6 +58,12 @@ REQUEST_ERRORS  = { 307: ['Temporary Redirect', 'Particular requests can deliver
 
 CREDENTIALS_PATH = Path.cwd().joinpath('credentials.json')
 
+USER_AGENT_HEADER = {
+    "Darwin": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36",
+    "Windows": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36",
+    "Linux": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36",
+}
+
 REQUEST_HEADERS = {
     "authority": "cardmarket.com",
     "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
@@ -71,7 +78,7 @@ REQUEST_HEADERS = {
     "sec-fetch-site": "none",
     "sec-fetch-user": "?1",
     "Upgrade-Insecure-Requests": "1",
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36"
+    "User-Agent": USER_AGENT_HEADER[platform.system()]
 }
 
 


### PR DESCRIPTION
YuGiOh wantslists did not contain <td> tags for isReverse. This would shift all of the indexes after isReverse by one.

This PR finds the indexes dynamically and sets them to None, if the element does not exist. isReverse is now only set for CURR_GAME="Pokemon"